### PR TITLE
Fix build with current emscripten

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,8 @@ EMX_FLAGS :=
 EMX_FLAGS += -Os
 EMX_FLAGS += -s EXPORT_ES6=1
 EMX_FLAGS += -s MODULARIZE=1
-EMX_FLAGS += -s USE_ES6_IMPORT_META=0
+EMX_FLAGS += -s USE_ES6_IMPORT_META=1
 EMX_FLAGS += -s EXPORT_NAME='promise'
-EMX_FLAGS += -s WASM_ASYNC_COMPILATION=0
 EMX_FLAGS += -s ALLOW_MEMORY_GROWTH=1
 EMX_FLAGS += -s ALLOW_TABLE_GROWTH=1
 EMX_FLAGS += -s INITIAL_MEMORY=8MB
@@ -31,14 +30,14 @@ node: lmfit
 	emcc $(EMX_FLAGS) -I$(LMFIT_SRC)/lib $(LMFIT_SRC)/build/lib/liblmfit.a src/lmfit.js.c \
 	-s ENVIRONMENT="node" \
 	-s EXPORTED_RUNTIME_METHODS="[addFunction, removeFunction, getValue, cwrap]" \
-	-s EXPORTED_FUNCTIONS="[_do_fit]" \
+	-s EXPORTED_FUNCTIONS="[_do_fit, _malloc, _free]" \
 	-o $(BUILD_DIR)/lmfit.js;
 
 web: lmfit
 	emcc $(EMX_FLAGS) -I$(LMFIT_SRC)/lib $(LMFIT_SRC)/build/lib/liblmfit.a src/lmfit.js.c \
 	-s ENVIRONMENT="worker" \
 	-s EXPORTED_RUNTIME_METHODS="[addFunction, removeFunction, getValue, cwrap]" \
-	-s EXPORTED_FUNCTIONS="[_do_fit]" \
+	-s EXPORTED_FUNCTIONS="[_do_fit, _malloc, _free]" \
 	-o $(BUILD_DIR)/lmfit.web.js;
 
 lmfit: dir lmfit-patch


### PR DESCRIPTION
Hello - thanks for making this library!

I think these changes are required to work with current emscripten:

* `EXPORT_ES6` and `ENVIRONMENT=*node*` requires `USE_ES6_IMPORT_META` to be set. This changed in https://github.com/emscripten-core/emscripten/pull/17915.

* `_malloc` and `_free` must be declared as exported functions to avoid removal by the compiler.

* Remove [`WASM_ASYNC_COMPILATION=0`](https://emsettings.surma.technology/#WASM_ASYNC_COMPILATION). The current code was broken by https://github.com/emscripten-core/emscripten/pull/12650. Previously, `WASM_ASYNC_COMPILATION=0` would return `Promise<Module>`, but that PR made it return `Module` directly. (Took ages to find the cause of this!)

  Removing the flag to keep it async avoids a breaking change in this library. Node.js v14.8.0 and later support top-level await, so async isn't that ugly. Alternatively, the Node.js version could easily be changed to load synchronously. Node.js has no limit on the size of synchronously loaded WebAssembly modules, unlike Chromium. I see spl.js uses synchronous loading. I'm happy to make this change if you prefer.

With these changes, I can build and it works with Node.js. I cannot get the webworker example to work though. My attempt to fix it so far is https://github.com/primitybio/lmfit.js/commit/74fab5a4f7de6dee74428d5556c4c44702a57c96. I don't know how your examples would work without a server due to CORS.

---

I have several other commits lined up, [one of which improves performance by 2x](https://github.com/primitybio/lmfit.js/commit/50adaa1c3989eed3308bca707398e4ac85f54903). I can also work on updating to the latest lmfit later.